### PR TITLE
Exclude dev stuff from package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml export-ignore
+src/SafeArrayReadTest.php export-ignore


### PR DESCRIPTION
With a .gitattributes file and the `export-ignore` attribute, files used
only for development can be excluded from distribution packages. This
will exclude, for example, the test stuff from package installed via
composer.